### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 :spring_version: current
 :spring_boot_version: 1.5.10.RELEASE
-:Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:View: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/View.html
-:Model: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/ui/Model.html
+:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:DispatcherServlet: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:View: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/View.html
+:Model: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/ui/Model.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -60,7 +60,7 @@ The `greetingForm()` method uses a {Model}[`Model`] object to expose a new `Gree
 include::complete/src/main/java/hello/Greeting.java[]
 ----
 
-The implementation of the method body relies on a link:/understanding/view-templates[view technology] to perform server-side rendering of the HTML by converting the view name "greeting" into a template to render. In this case we are using http://www.thymeleaf.org/doc/html/Thymeleaf-Spring3.html[Thymeleaf], which parses the `greeting.html` template below and evaluates the various template expressions to render the form.
+The implementation of the method body relies on a link:/understanding/view-templates[view technology] to perform server-side rendering of the HTML by converting the view name "greeting" into a template to render. In this case we are using https://www.thymeleaf.org/doc/html/Thymeleaf-Spring3.html[Thymeleaf], which parses the `greeting.html` template below and evaluates the various template expressions to render the form.
 
 `src/main/resources/templates/greeting.html`
 [source,html]

--- a/complete/src/main/resources/templates/greeting.html
+++ b/complete/src/main/resources/templates/greeting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head> 
     <title>Getting Started: Handling Form Submission</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/complete/src/main/resources/templates/result.html
+++ b/complete/src/main/resources/templates/result.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head> 
     <title>Getting Started: Handling Form Submission</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://www.thymeleaf.org with 2 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://www.thymeleaf.org/doc/html/Thymeleaf-Spring3.html with 1 occurrences migrated to:  
  https://www.thymeleaf.org/doc/html/Thymeleaf-Spring3.html ([https](https://www.thymeleaf.org/doc/html/Thymeleaf-Spring3.html) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/greeting with 2 occurrences