### PR TITLE
Fixing broken links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,7 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/how_to_complete_this_guide.adoc[]
 
+[[scratch]]
 == Starting with Spring Initializr
 
 For all Spring applications, you should start with the https://start.spring.io[Spring


### PR DESCRIPTION
how_to_complete_this_guide.adoc includes links to anchors called `scratch` and `
internal`. I'm making sure those anchors exist. Sometimes, that requires rearran
ging content.